### PR TITLE
[#8] User Domain module init

### DIFF
--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/UserExceptionType.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/UserExceptionType.java
@@ -1,0 +1,27 @@
+package kr.flab.snapnow.domain.user.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import kr.flab.snapnow.core.enums.ResultCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserExceptionType implements ResultCode {
+
+    USER_NOT_FOUND("User not found"),
+    DELETED_USER("Deleted user"),
+    USER_ALREADY_EXISTS("User already exists"),
+
+    // UserAccount
+    EMAIL_AUTH_ATTEMPT_EXCEEDED("Email auth attempt exceeded"),
+    INVALID_VERIFICATION_CODE("Invalid verification code"),
+    EMAIL_NOT_VERIFIED("Email not verified"),
+
+    // UserProfile
+    USER_NAME_ALREADY_EXISTS("User name already exists");
+    ;
+
+    private final String message;
+}
+

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/DeletedUserException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/DeletedUserException.java
@@ -1,0 +1,23 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.BadRequestException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class DeletedUserException extends BadRequestException {
+
+    public DeletedUserException() {
+        super(UserExceptionType.DELETED_USER);
+    }
+
+    public DeletedUserException(UserExceptionType userExceptionType) {
+        super(userExceptionType);
+    }
+
+    public DeletedUserException(String message) {
+        super(UserExceptionType.DELETED_USER, message);
+    }
+
+    public DeletedUserException(Throwable cause) {
+        super(UserExceptionType.DELETED_USER, cause);
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/EmailAuthAttemptExceededException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/EmailAuthAttemptExceededException.java
@@ -1,0 +1,23 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.BadRequestException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class EmailAuthAttemptExceededException extends BadRequestException {
+
+    public EmailAuthAttemptExceededException() {
+        super(UserExceptionType.EMAIL_AUTH_ATTEMPT_EXCEEDED);
+    }
+
+    public EmailAuthAttemptExceededException(String message) {
+        super(UserExceptionType.EMAIL_AUTH_ATTEMPT_EXCEEDED, message);
+    }
+
+    public EmailAuthAttemptExceededException(Throwable cause) {
+        super(UserExceptionType.EMAIL_AUTH_ATTEMPT_EXCEEDED, cause);
+    }
+
+    public EmailAuthAttemptExceededException(String message, Throwable cause) {
+        super(UserExceptionType.EMAIL_AUTH_ATTEMPT_EXCEEDED, message, cause);
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/EmailVerificationException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/EmailVerificationException.java
@@ -1,0 +1,25 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.UnAuthorizedException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class EmailVerificationException extends UnAuthorizedException {
+
+    public EmailVerificationException() {
+        super(UserExceptionType.EMAIL_NOT_VERIFIED);
+    }
+
+    public EmailVerificationException(UserExceptionType exceptionType) {
+        super(exceptionType);
+    }
+
+    public EmailVerificationException(String message) {
+        super(UserExceptionType.EMAIL_NOT_VERIFIED, message);
+    }
+
+    public EmailVerificationException(Throwable cause) {
+        super(UserExceptionType.EMAIL_NOT_VERIFIED, cause);
+    }
+
+    
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/InvalidVerificationCodeException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/InvalidVerificationCodeException.java
@@ -1,0 +1,23 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.BadRequestException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class InvalidVerificationCodeException extends BadRequestException {
+
+    public InvalidVerificationCodeException() {
+        super(UserExceptionType.INVALID_VERIFICATION_CODE);
+    }
+
+    public InvalidVerificationCodeException(String message) {
+        super(UserExceptionType.INVALID_VERIFICATION_CODE, message);
+    }
+
+    public InvalidVerificationCodeException(Throwable cause) {
+        super(UserExceptionType.INVALID_VERIFICATION_CODE, cause);
+    }
+
+    public InvalidVerificationCodeException(String message, Throwable cause) {
+        super(UserExceptionType.INVALID_VERIFICATION_CODE, message, cause);
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/UserAlreadyExistException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/UserAlreadyExistException.java
@@ -1,0 +1,23 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.BadRequestException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class UserAlreadyExistException extends BadRequestException {
+
+    public UserAlreadyExistException() {
+        super(UserExceptionType.USER_ALREADY_EXISTS);
+    }
+
+    public UserAlreadyExistException(UserExceptionType userExceptionType) {
+        super(userExceptionType);
+    }
+
+    public UserAlreadyExistException(String message) {
+        super(UserExceptionType.USER_ALREADY_EXISTS, message);
+    }
+
+    public UserAlreadyExistException(Throwable cause) {
+        super(UserExceptionType.USER_ALREADY_EXISTS, cause);
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/UserNotFoundException.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,23 @@
+package kr.flab.snapnow.domain.user.domain.exception;
+
+import kr.flab.snapnow.core.exception.NotFoundException;
+import kr.flab.snapnow.domain.user.domain.enums.UserExceptionType;
+
+public class UserNotFoundException extends NotFoundException {
+
+    public UserNotFoundException() {
+        super(UserExceptionType.USER_NOT_FOUND);
+    }
+
+    public UserNotFoundException(UserExceptionType userExceptionType) {
+        super(userExceptionType);
+    }
+
+    public UserNotFoundException(String message) {
+        super(UserExceptionType.USER_NOT_FOUND, message);
+    }
+
+    public UserNotFoundException(Throwable cause) {
+        super(UserExceptionType.USER_NOT_FOUND, cause);
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: close #8 

## 📝 Purpose of PR

Please briefly explain your work in this PR.

## Contents

### 피드백 & 추후 고민해봐야하는 사항
이것을 따로 클래스로 정의하는 것이 어떤 의미를 갖는가?
이로 인해 얻는 이점이 잃는 것보다 큰가?
팀원이 있다면 어떻게 설득할 것인가?
클래스로 나누는 기준이 어떻게 되는가?
여러 개를 하나로 묶는다면 그 기준이 어떻게 되는가?

### 복잡성 증가와 생산성 저하
이것에 대한 우선선위는 어떠한가? LOW이다. 없어도 프로그램은 잘 돌아간다.
하지만 가장 먼저 구현한다.
예외 케이스를 먼저 정의하기 위해서.
시간은 어느 정도 소요되는가?
단순히 만드는 것 자체는 오래걸리지 않는다.
다만 이를 위해서 고려하게 되는 경우가 많다.
예외 처리를 어디까지 커스텀하게 처리할 것인가?
예외 처리에 대한 일관성을 지키기 위해 builder의 build()를 오버라이딩하여 유효성 검증 로직을 넣었다.
그럼에도 유지할 정도의 가치가 있는가?

### custom exception을 사용하는 이유는 무엇일까?
- 이름 자체로 어떤 에러인지 확인하기 편리할 수 있다.
- 표준 예외의 경우 그 자체만으로는 어디서 발생했는지 알기가 어렵다.
    - 물론 메시지로 구분할 수 있지만, 메세지를 직접 확인하는 번거로움이 있다.
- '내가 발생할 수 있다고 선언한 예외'에 대한 처리를 명확히 할 수 있다.
    - 예시로, 내가 선언한 BadRequestException은 400 상태코드를 반환하고, 내가 선언하지 않은 표준 BadRequestException은 500 상태코드를 반환하여 예측 가능한 예외 외로는 INTERNAL_SERVER_ERROR로 처리하는 것이다.
- custom한 예외별 code를 설정하여 client에게 전달할 수 있다.
    - client에서 반환되는 예외 코드에 따라 다른 행동을 해야한다고 할 때 유용하다.
    - 이를 메세지로 처리하지 못할 이유가 있을까?
        - 만약 같은 예외에 대해서 개발자가 달라 다른 메세지를 반환하는 경우, 메세지만으로 판단할 수 없다.
        - 일관성을 유지하기 위한 '규약'이라고 생각하면 좋을 듯 하다.
- 해당 예외를 catch해야하는 경우
    - custom한 처리를 하는 경우
        - 예시로, 이메일 인증에 n회 이상 실패하는 경우 24시간동안 인증을 제한하는 것을 구현하고 싶은 경우, 표준 예외로 처리하는 경우 다른 케이스로 인해 발생한 예외와 겹칠 수 있다.

### 앞으로 어떻게 할 것인가?
당장에 우선순위가 높지 않은 일에 많은 것을 할당할 수는 없다.
client에게 전달해야하는 주요한 사항에 대해서, 도메인 로직에 명확히 연관된 경우에만 custom exception을 사용한다.
- resultCode에 대한 enum을 정의함으로써 모든 에외를 한 곳에서 볼 수 있으며, api 명세에서도 명확히 선언해놓을 수 있다.
- 중요한 것들이니 따로 정의하는 의미도 있다.
- 예시로 일반적인 유효성을 따지는 것들은 모두 IllegalArgumentExeption으로 처리하되 인증 횟수 초과, 인증코드 틀림, AlreadyExist, NotFound 등은 커스텀하게 처리한다.

## Checklist

-   [x] Does commit messages follow the convention?
-   [x] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
