### PR TITLE
[#8] User Account Domain Model

### DIFF
--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/enums/FollowNotification.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/enums/FollowNotification.java
@@ -1,0 +1,20 @@
+package kr.flab.snapnow.domain.follow.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FollowNotification {
+
+    ALL("All", "Accept all follow activities"),
+    SOME("Some", "Accept only snap request and tag"),
+    TURN_OFF("Turn Off", "Turn off all activities");
+
+    private final String value;
+    private final String description;
+
+    public static FollowNotification getDefault() {
+        return ALL;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/enums/FollowStatus.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/enums/FollowStatus.java
@@ -1,0 +1,17 @@
+package kr.flab.snapnow.domain.follow.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FollowStatus {
+
+    FOLLOWING("following"),
+    FOLLOWED("followed"),
+    BLOCKED("blocked"),
+    NONE("none"),
+    SELF("self");
+
+    private final String value;
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
@@ -1,0 +1,51 @@
+package kr.flab.snapnow.domain.follow.domain.model;
+
+import lombok.Getter;
+import lombok.Builder;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import kr.flab.snapnow.domain.follow.domain.enums.FollowStatus;
+import kr.flab.snapnow.domain.follow.domain.enums.FollowNotification;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Follow {
+
+    private Long userId;
+    private Long targetUserId;
+
+    private FollowStatus followStatus;
+    private FollowNotification followNotification;
+
+    private Follow(Long userId, Long targetUserId, FollowStatus followStatus,
+            FollowNotification followNotification) {
+        if (userId == null) {
+            userId = targetUserId;
+        }
+        if (userId == targetUserId || followStatus == null) {
+            followStatus = FollowStatus.SELF;
+        }
+        if (followStatus == FollowStatus.FOLLOWING && followNotification == null) {
+            followNotification = FollowNotification.getDefault();
+        }
+        if (followStatus != FollowStatus.FOLLOWING && followNotification != null) {
+            followNotification = null;
+        }
+        this.userId = userId;
+        this.targetUserId = targetUserId;
+        this.followStatus = followStatus;
+        this.followNotification = followNotification;
+    }
+
+    public void updateFollowNotification(FollowNotification followNotification) {
+        if (followStatus != FollowStatus.FOLLOWING) {
+            return;
+        }
+        if (followNotification == null) {
+            followNotification = FollowNotification.getDefault();
+        }
+        this.followNotification = followNotification;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
@@ -41,7 +41,8 @@ public class Follow {
 
     public void updateFollowNotification(FollowNotification followNotification) {
         if (followStatus != FollowStatus.FOLLOWING) {
-            return;
+            throw new IllegalArgumentException(
+                "Cannot update follow notification for non-following user");
         }
         if (followNotification == null) {
             followNotification = FollowNotification.getDefault();

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/follow/domain/model/Follow.java
@@ -39,6 +39,13 @@ public class Follow {
         this.followNotification = followNotification;
     }
 
+    public void updateFollowStatus(FollowStatus followStatus) {
+        if (followStatus == null) {
+            throw new IllegalArgumentException("Follow status cannot be null");
+        }
+        this.followStatus = followStatus;
+    }
+
     public void updateFollowNotification(FollowNotification followNotification) {
         if (followStatus != FollowStatus.FOLLOWING) {
             throw new IllegalArgumentException(

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/account/AuthProvider.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/account/AuthProvider.java
@@ -1,0 +1,30 @@
+package kr.flab.snapnow.domain.user.domain.enums.account;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthProvider {
+
+    EMAIL("email"),
+    KAKAO("kakao"),
+    NAVER("naver"),
+    GOOGLE("google"),
+    APPLE("apple");
+
+    private final String value;
+
+    public static AuthProvider of(String value) {
+        return Arrays.stream(AuthProvider.values())
+                .filter(authProvider -> authProvider.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid AuthProvider value: " + value));
+    }
+
+    public String getCode() {
+        return name();
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/account/Gender.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/enums/account/Gender.java
@@ -1,0 +1,37 @@
+package kr.flab.snapnow.domain.user.domain.enums.account;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+
+    UNKNOWN("Unknown"),
+    PRIVATE("Private"),
+    MALE("Male"),
+    FEMALE("Female"),
+    BISEXUAL("Bysexual"),
+    NEUTRAL("Neutral"),
+    ;
+
+    private final String value;
+
+    public static Gender getDefault() {
+        return UNKNOWN;
+    }
+
+    public static Gender of(String value) {
+        return Arrays.stream(Gender.values())
+                .filter(gender -> gender.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Gender value: " + value));
+    }
+
+
+    public String getCode() {
+        return name();
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/UserAccount.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/UserAccount.java
@@ -1,0 +1,27 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount;
+
+import lombok.Getter;
+import kr.flab.snapnow.domain.user.domain.model.userAccount.credential.UserCredential;
+import lombok.Builder;
+
+@Getter
+@Builder
+public class UserAccount {
+
+    private Long userId;
+    private UserCredential credential;
+    private UserAccountInfo info;
+
+    @Builder
+    protected UserAccount(Long userId, UserCredential credential, UserAccountInfo info) {
+        if (credential == null) {
+            throw new IllegalArgumentException("UserAccount credential is null");
+        }
+        if (info == null) {
+            throw new IllegalArgumentException("UserAccount info is null");
+        }
+        this.userId = userId;
+        this.credential = credential;
+        this.info = info;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/UserAccountInfo.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/UserAccountInfo.java
@@ -1,0 +1,57 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount;
+
+import java.time.LocalDate;
+import java.util.Locale;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import kr.flab.snapnow.domain.user.domain.enums.account.Gender;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserAccountInfo {
+
+    private String name;
+    private LocalDate birthDay;
+    private String phoneNumber;
+
+    @Builder.Default
+    private Gender gender = Gender.getDefault();
+
+    @Builder.Default
+    private Locale locale = Locale.KOREA;
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateBirthDay(LocalDate birthDay) {
+        this.birthDay = birthDay;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateGender(Gender gender) {
+        if (gender == null) {
+            this.gender = Gender.getDefault();
+            return;
+        }
+        this.gender = gender;
+    }
+
+    public void updateLocale(Locale locale) {
+        if (locale == null) {
+            this.locale = Locale.KOREA;
+            return;
+        }
+        this.locale = locale;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/Email.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/Email.java
@@ -1,0 +1,48 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
+
+import lombok.Getter;
+
+@Getter
+public class Email {
+
+    private String value;
+
+    private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+    public Email(String email) {
+        validateEmail(email);
+        this.value = email;
+    }
+    
+    public void updateEmail(String email) {
+        if (this.value != null) {
+            throw new IllegalStateException("Email is already set");
+        }
+        
+        validateEmail(email);
+        this.value = email;
+    }
+    
+    private void validateEmail(String email) {
+        if (email != null && !email.matches(EMAIL_REGEX)) {
+            throw new IllegalArgumentException("Invalid email format");
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        Email email = (Email) obj;
+        return value.equals(email.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/EmailCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/EmailCredential.java
@@ -1,0 +1,21 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
+
+import lombok.Getter;
+import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
+import lombok.Builder;
+
+@Getter
+@Builder
+public class EmailCredential extends UserCredential {
+
+    private String password;
+
+    @Builder
+    private EmailCredential(Email email, String password) {
+        super(AuthProvider.EMAIL, email);
+        if (password == null) {
+            throw new IllegalArgumentException("Password is required");
+        }
+        this.password = password;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/EmailCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/EmailCredential.java
@@ -1,16 +1,16 @@
 package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
 
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
 import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
-import lombok.Builder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class EmailCredential extends UserCredential {
 
     private String password;
 
-    @Builder
     private EmailCredential(Email email, String password) {
         super(AuthProvider.EMAIL, email);
         if (password == null) {

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/OAuthCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/OAuthCredential.java
@@ -1,16 +1,16 @@
 package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
 
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
 import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
-import lombok.Builder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class OAuthCredential extends UserCredential {
 
     private String providerId;
 
-    @Builder
     private OAuthCredential(AuthProvider authProvider, String providerId, Email email) {
         super(authProvider, email);
         if (providerId == null) {

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/OAuthCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/OAuthCredential.java
@@ -1,0 +1,21 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
+
+import lombok.Getter;
+import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
+import lombok.Builder;
+
+@Getter
+@Builder
+public class OAuthCredential extends UserCredential {
+
+    private String providerId;
+
+    @Builder
+    private OAuthCredential(AuthProvider authProvider, String providerId, Email email) {
+        super(authProvider, email);
+        if (providerId == null) {
+            throw new IllegalArgumentException("Provider ID is required");
+        }
+        this.providerId = providerId;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/UserCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/UserCredential.java
@@ -1,0 +1,22 @@
+package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
+
+import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
+import lombok.Getter;
+
+@Getter
+public abstract class UserCredential {
+
+    protected AuthProvider authProvider;
+    protected Email email;
+
+    protected UserCredential(AuthProvider authProvider, Email email) {
+        if (authProvider == null) {
+            throw new IllegalArgumentException("Auth provider is required");
+        }
+        if (email == null) {
+            throw new IllegalArgumentException("Email is required");
+        }
+        this.authProvider = authProvider;
+        this.email = email;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/UserCredential.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userAccount/credential/UserCredential.java
@@ -1,9 +1,12 @@
 package kr.flab.snapnow.domain.user.domain.model.userAccount.credential;
 
-import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import kr.flab.snapnow.domain.user.domain.enums.account.AuthProvider;
 
 @Getter
+@SuperBuilder
 public abstract class UserCredential {
 
     protected AuthProvider authProvider;

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userProfile/FullProfile.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userProfile/FullProfile.java
@@ -1,0 +1,28 @@
+package kr.flab.snapnow.domain.user.domain.model.userProfile;
+
+import lombok.Getter;
+import lombok.Builder;
+
+import kr.flab.snapnow.domain.follow.domain.model.Follow;
+
+@Getter
+@Builder
+public class FullProfile {
+
+    private UserProfile userProfile;
+
+    private int postCount;
+    private int followerCount;
+    private int followingCount;
+
+    private Follow follow;
+
+    @Builder
+    protected FullProfile(UserProfile userProfile, int postCount, int followerCount,
+            int followingCount, Follow follow) {
+        this.postCount = postCount;
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+        this.follow = follow;
+    }
+}

--- a/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userProfile/UserProfile.java
+++ b/snapnow-domain/src/main/java/kr/flab/snapnow/domain/user/domain/model/userProfile/UserProfile.java
@@ -1,0 +1,38 @@
+package kr.flab.snapnow.domain.user.domain.model.userProfile;
+
+import lombok.Getter;
+import lombok.Builder;
+import kr.flab.snapnow.domain.follow.domain.enums.FollowStatus;
+
+@Getter
+@Builder
+public class UserProfile {
+
+    private Long userId;
+    private String userName;
+    private String fullName;
+    private String biography;
+    private String profileImageUrl;
+
+    private FollowStatus followStatus;
+
+    protected UserProfile(Long userId, String userName, String fullName, String biography,
+            String profileImageUrl, FollowStatus followStatus) {
+        if (userName == null) {
+            throw new IllegalArgumentException("User name is required");
+        }
+        if (profileImageUrl == null) {
+            throw new IllegalArgumentException("Profile image URL is required");
+        }
+        if (followStatus == null) {
+            followStatus = FollowStatus.SELF;
+        }
+
+        this.userId = userId;
+        this.userName = userName;
+        this.fullName = fullName;
+        this.biography = biography;
+        this.profileImageUrl = profileImageUrl;
+        this.followStatus = followStatus;
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: #8 

## 📝 Purpose of PR

user account에 대한 모델들을 구현한다.

## Contents

- userAccount는 credential과 accountInfo를 갖는다.
- 이때 credential은 자격증명, 로그인을 위한 필수 정보가 들어간다고 보면 된다.
- OAuthCredential은 providerId가 필수이며, EmailCredential은 password가 필수이다.

## Checklist

-   [x] Does commit messages follow the convention?
-   [x] Are variable names brief but descriptive?
-   [x] Is the code clean and easy to understand?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
